### PR TITLE
Support for installing via composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,16 @@
+{
+	"name": "paygate/payweb-woocommerce",
+	"description": "Performance optimization plugin for WordPress",
+	"keywords": [
+		"payment gateway"
+	],
+	"homepage": "https://www.paygate.co.za",
+	"authors": [
+		{
+			"name": "PayGate",
+			"email": "support@paygate.co.za",
+			"homepage": "https://www.paygate.co.za/"
+		}
+	],
+	"type": "wordpress-plugin"
+}


### PR DESCRIPTION
This file will allow the plugin to be installed via composer. You just need to create an account on https://packagist.org and add the repo there. Just make sure you update `name` to match what you create on Packagist.